### PR TITLE
fix: Zod 4 manifest schema generation + SSRF-compatible media fetching

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "openclaw": "^2026.4.5",
     "tsup": "^8.5.0",
     "tsx": "^4.20.5",
-    "typescript": "^5.7.3",
-    "zod-to-json-schema": "^3.24.6"
+    "typescript": "^5.7.3"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/scripts/generate-manifest-schema.ts
+++ b/scripts/generate-manifest-schema.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { zodToJsonSchema } from "zod-to-json-schema";
+import { z } from "zod";
 import { RocketChatConfigSchema } from "../src/config-schema.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -14,14 +14,7 @@ const packageJsonPath = path.join(pluginRoot, "package.json");
 const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as Record<string, any>;
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as { version: string };
 
-const jsonSchema = zodToJsonSchema(
-  RocketChatConfigSchema as unknown as Parameters<typeof zodToJsonSchema>[0],
-  {
-    name: "RocketChatConfig",
-    target: "jsonSchema7",
-    $refStrategy: "none",
-  },
-);
+const jsonSchema = z.toJSONSchema(RocketChatConfigSchema, { target: "draft-7" });
 
 manifest.version = packageJson.version;
 manifest.configSchema = jsonSchema;

--- a/src/rocketchat/client.ts
+++ b/src/rocketchat/client.ts
@@ -241,7 +241,7 @@ export async function uploadFile(
   }
   const uploadData = (await uploadRes.json()) as { file?: { _id: string; url: string }; success?: boolean };
   if (!uploadData.success || !uploadData.file?.url) {
-    throw new Error("Rocket.Chat file upload failed: no file URL returned");
+    throw new Error(`Rocket.Chat file upload failed: status=${uploadRes.status}, body=${JSON.stringify(uploadData)}`);
   }
 
   // Step 2: Determine attachment type and absolute URL

--- a/src/rocketchat/monitor.ts
+++ b/src/rocketchat/monitor.ts
@@ -17,7 +17,7 @@ import {
   recordPendingHistoryEntryIfEnabled,
 } from "openclaw/plugin-sdk/reply-history";
 import { resolveControlCommandGate } from "openclaw/plugin-sdk/command-auth";
-import { resolveChannelMediaMaxBytes } from "openclaw/plugin-sdk/media-runtime";
+import { resolveChannelMediaMaxBytes, getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import {
   createConversationWindowTracker,
   evaluateRocketChatMentionGate,
@@ -322,11 +322,11 @@ export async function monitorRocketChatProvider(opts: MonitorRocketChatOpts = {}
   const channelHistories = new Map<string, HistoryEntry[]>();
   const conversationWindows = createConversationWindowTracker();
 
-  const fetchWithAuth = (input: URL | string, init?: RequestInit) => {
-    const headers = new Headers(init?.headers);
-    headers.set("X-Auth-Token", client.authToken);
-    headers.set("X-User-Id", client.userId);
-    return fetch(input, { ...init, headers });
+  const authRequestInit: RequestInit = {
+    headers: {
+      "X-Auth-Token": client.authToken,
+      "X-User-Id": client.userId,
+    },
   };
 
   const resolveMedia = async (msg: RocketChatMessage): Promise<RocketChatMediaInfo[]> => {
@@ -340,7 +340,7 @@ export async function monitorRocketChatProvider(opts: MonitorRocketChatOpts = {}
         const url = `${client.baseUrl}/file-upload/${file._id}/${encodeURIComponent(file.name ?? file._id)}`;
         const fetched = await core.channel.media.fetchRemoteMedia({
           url,
-          fetchImpl: fetchWithAuth,
+          requestInit: authRequestInit,
           filePathHint: file.name ?? file._id,
           maxBytes: mediaMaxBytes,
           ssrfPolicy: { allowedHostnames: [new URL(client.baseUrl).hostname] },
@@ -358,7 +358,7 @@ export async function monitorRocketChatProvider(opts: MonitorRocketChatOpts = {}
           kind: core.media.mediaKindFromMime(contentType) ?? "unknown",
         });
       } catch (err) {
-        logger.debug?.(`rocketchat: failed to download file ${file._id}: ${String(err)}`);
+        logger.info?.(`rocketchat: failed to download file ${file._id}: ${String(err)}`);
       }
     }
 
@@ -371,7 +371,7 @@ export async function monitorRocketChatProvider(opts: MonitorRocketChatOpts = {}
       try {
         const fetched = await core.channel.media.fetchRemoteMedia({
           url: fullUrl,
-          fetchImpl: fetchWithAuth,
+          requestInit: authRequestInit,
           filePathHint: att.title ?? "attachment",
           maxBytes: mediaMaxBytes,
           ssrfPolicy: { allowedHostnames: [new URL(client.baseUrl).hostname] },
@@ -867,6 +867,7 @@ export async function monitorRocketChatProvider(opts: MonitorRocketChatOpts = {}
               await sendMessageRocketChat(to, caption, {
                 accountId: account.accountId,
                 mediaUrl,
+                mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, route.agentId),
                 replyToId: threadRootId,
               });
             }


### PR DESCRIPTION
## Summary

Two fixes for OpenClaw 2026.4.x compatibility:

### 1. Fix empty `configSchema` in manifest (Zod 4 migration)

The `openclaw` peer dependency now ships Zod 4, which changed its internal schema representation. The third-party `zod-to-json-schema` library silently produces empty definitions with Zod 4, resulting in `openclaw.plugin.json` shipping a `configSchema` with no type information. This breaks manifest-level config validation.

Replaced with Zod 4's native `z.toJSONSchema()` method and removed the `zod-to-json-schema` dev dependency.

### 2. Use `requestInit` instead of `fetchImpl` for inbound media

OpenClaw 2026.4.x added SSRF guard dispatchers to `fetchRemoteMedia` that reject custom `fetchImpl` wrappers with `invalid onRequestStart method`, silently breaking all inbound media (images, audio, documents).

Passes auth headers via the `requestInit` parameter instead of wrapping fetch, matching the `FetchMediaOptions` contract. Also adds `mediaLocalRoots` to the deliver callback for outbound media support (pending openclaw/openclaw#64529 to fully unblock TTS delivery).

Elevates media download failure logging from `debug` to `info` so fetch errors are visible without debug-level logging.

### 3. Improved upload error detail

`uploadFile` error now includes HTTP status and response body for easier debugging of outbound media failures.

## Testing

All existing tests pass. Inbound image vision confirmed working on Rocket.Chat 8.3.1 + OpenClaw 2026.4.9.