### PR TITLE
Handle Rocket.Chat 429 login rate limiting

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "rocketchat",
   "name": "Rocket.Chat",
   "description": "Rocket.Chat channel plugin",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "channels": [
     "rocketchat"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alexwoo-awso/openclaw-rocketchat",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alexwoo-awso/openclaw-rocketchat",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "MIT",
       "dependencies": {
         "openclaw": "^2026.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alexwoo-awso/openclaw-rocketchat",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "OpenClaw Rocket.Chat channel plugin",
   "license": "MIT",
   "type": "module",

--- a/src/rocketchat/client.ts
+++ b/src/rocketchat/client.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { normalizeRocketChatBaseUrl } from "./base-url.js";
 
 export type RocketChatClient = {
@@ -59,6 +61,49 @@ function buildApiUrl(baseUrl: string, path: string): string {
   }
   const suffix = path.startsWith("/") ? path : `/${path}`;
   return `${normalized}/api/v1${suffix}`;
+}
+
+type RocketChatLoginSession = {
+  authToken: string;
+  userId: string;
+};
+
+type RocketChatLoginCacheEntry = {
+  session?: RocketChatLoginSession;
+  inFlight?: Promise<RocketChatLoginSession>;
+};
+
+const rocketChatLoginCache = new Map<string, RocketChatLoginCacheEntry>();
+const MAX_LOGIN_RATE_LIMIT_RETRIES = 2;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function loginCacheKey(baseUrl: string, username: string, password: string): string {
+  const passwordHash = createHash("sha256").update(password).digest("hex").slice(0, 16);
+  return `${baseUrl}::${username}::sha256:${passwordHash}`;
+}
+
+function parseRetryAfterMs(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const seconds = Number.parseInt(value, 10);
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, seconds * 1000);
+  }
+  const when = Date.parse(value);
+  if (Number.isFinite(when)) {
+    return Math.max(0, when - Date.now());
+  }
+  return undefined;
+}
+
+function parseRateLimitDelayMs(detail: string): number | undefined {
+  const match = detail.match(/wait\s+(\d+)\s+seconds?/i);
+  if (!match) return undefined;
+  const seconds = Number.parseInt(match[1] ?? "", 10);
+  if (!Number.isFinite(seconds)) return undefined;
+  return Math.max(0, seconds * 1000);
 }
 
 async function readRocketChatError(res: Response): Promise<string> {
@@ -339,30 +384,69 @@ export async function loginWithPassword(params: {
   username: string;
   password: string;
   fetchImpl?: typeof fetch;
+  forceRefresh?: boolean;
 }): Promise<{ authToken: string; userId: string }> {
   const baseUrl = normalizeRocketChatBaseUrl(params.baseUrl);
   if (!baseUrl) {
     throw new Error("Rocket.Chat baseUrl is required for login");
   }
   const fetchImpl = params.fetchImpl ?? fetch;
-  const url = `${baseUrl}/api/v1/login`;
-  const res = await fetchImpl(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ user: params.username, password: params.password }),
-  });
-  if (!res.ok) {
-    const detail = await readRocketChatError(res);
-    throw new Error(`Rocket.Chat login failed (${res.status}): ${detail}`);
+  const key = loginCacheKey(baseUrl, params.username, params.password);
+  const entry = rocketChatLoginCache.get(key) ?? {};
+  if (params.forceRefresh) {
+    delete entry.session;
   }
-  const data = (await res.json()) as {
-    status?: string;
-    data?: { authToken?: string; userId?: string };
-  };
-  const authToken = data.data?.authToken;
-  const userId = data.data?.userId;
-  if (!authToken || !userId) {
-    throw new Error("Rocket.Chat login succeeded but no token/userId returned");
+  if (entry.session) {
+    rocketChatLoginCache.set(key, entry);
+    return entry.session;
   }
-  return { authToken, userId };
+  if (entry.inFlight) {
+    rocketChatLoginCache.set(key, entry);
+    return entry.inFlight;
+  }
+
+  const loginPromise = (async (): Promise<RocketChatLoginSession> => {
+    const url = `${baseUrl}/api/v1/login`;
+    for (let attempt = 0; ; attempt += 1) {
+      const res = await fetchImpl(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ user: params.username, password: params.password }),
+      });
+      if (!res.ok) {
+        const detail = await readRocketChatError(res);
+        if (res.status === 429 && attempt < MAX_LOGIN_RATE_LIMIT_RETRIES) {
+          const retryAfterMs =
+            parseRetryAfterMs(res.headers.get("retry-after")) ?? parseRateLimitDelayMs(detail);
+          if (retryAfterMs !== undefined) {
+            await sleep(retryAfterMs);
+            continue;
+          }
+        }
+        throw new Error(`Rocket.Chat login failed (${res.status}): ${detail}`);
+      }
+      const data = (await res.json()) as {
+        status?: string;
+        data?: { authToken?: string; userId?: string };
+      };
+      const authToken = data.data?.authToken;
+      const userId = data.data?.userId;
+      if (!authToken || !userId) {
+        throw new Error("Rocket.Chat login succeeded but no token/userId returned");
+      }
+      return { authToken, userId };
+    }
+  })();
+
+  entry.inFlight = loginPromise;
+  rocketChatLoginCache.set(key, entry);
+
+  try {
+    const session = await loginPromise;
+    entry.session = session;
+    return session;
+  } finally {
+    delete entry.inFlight;
+    rocketChatLoginCache.set(key, entry);
+  }
 }

--- a/src/rocketchat/monitor.ts
+++ b/src/rocketchat/monitor.ts
@@ -282,9 +282,14 @@ export async function monitorRocketChatProvider(opts: MonitorRocketChatOpts = {}
   const canRelogin = Boolean(username && password);
 
   let reloginNeeded = false;
-  const relogin = async (): Promise<void> => {
+  const relogin = async (forceRefresh = false): Promise<void> => {
     if (!canRelogin || !username || !password) return;
-    const loginResult = await loginWithPassword({ baseUrl, username, password });
+    const loginResult = await loginWithPassword({
+      baseUrl,
+      username,
+      password,
+      forceRefresh,
+    });
     authToken = loginResult.authToken;
     userId = loginResult.userId;
   };
@@ -952,7 +957,7 @@ export async function monitorRocketChatProvider(opts: MonitorRocketChatOpts = {}
 
   const connectOnce = async (): Promise<void> => {
     if (reloginNeeded) {
-      await relogin();
+      await relogin(true);
       client = requireClientAuth({ baseUrl, authToken, userId });
       reloginNeeded = false;
     }

--- a/src/rocketchat/send.ts
+++ b/src/rocketchat/send.ts
@@ -52,6 +52,10 @@ function isHttpUrl(value: string): boolean {
   return /^https?:\/\//i.test(value);
 }
 
+function isRocketChatAuthError(error: unknown): boolean {
+  return error instanceof Error && /Rocket\.Chat API (401|403)\b/.test(error.message);
+}
+
 function parseRocketChatTarget(raw: string): RocketChatTarget {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -143,112 +147,140 @@ export async function sendMessageRocketChat(
       `Rocket.Chat baseUrl missing for account "${account.accountId}".`,
     );
   }
+  const username = account.username?.trim();
+  const password = account.password?.trim();
+  const canRelogin = Boolean(username && password);
 
-  // Fall back to username/password login if no token
-  if (!authToken || !userId) {
-    const username = account.username?.trim();
-    const password = account.password?.trim();
-    if (username && password && baseUrl) {
-      const loginResult = await loginWithPassword({ baseUrl, username, password });
+  const ensureAuth = async (forceRefresh = false): Promise<void> => {
+    if (!forceRefresh && authToken && userId) {
+      return;
+    }
+    if (username && password) {
+      const loginResult = await loginWithPassword({
+        baseUrl,
+        username,
+        password,
+        forceRefresh,
+      });
       authToken = loginResult.authToken;
       userId = loginResult.userId;
-    } else {
+      return;
+    }
+    if (!authToken || !userId) {
       throw new Error(
         `Rocket.Chat auth missing for account "${account.accountId}". Set authToken+userId or username+password.`,
       );
     }
-  }
+  };
 
-  const target = parseRocketChatTarget(to);
-  const roomId = await resolveTargetRoomId({
-    target,
-    baseUrl,
-    authToken,
-    userId,
-  });
+  await ensureAuth();
 
-  const client = createRocketChatClient({ baseUrl, authToken, userId });
-  let message = text?.trim() ?? "";
-  let uploadError: Error | undefined;
-  const mediaUrl = opts.mediaUrl?.trim();
+  const sendOnce = async (): Promise<RocketChatSendResult> => {
+    if (!authToken || !userId) {
+      throw new Error("Rocket.Chat auth missing after login");
+    }
+    const target = parseRocketChatTarget(to);
+    const roomId = await resolveTargetRoomId({
+      target,
+      baseUrl,
+      authToken,
+      userId,
+    });
 
-  if (mediaUrl) {
-    try {
-      const configuredMaxMb =
-        account.config.mediaMaxMb ??
-        cfg.channels?.rocketchat?.mediaMaxMb;
-      const maxBytes = configuredMaxMb && configuredMaxMb > 0
-        ? configuredMaxMb * 1024 * 1024
-        : undefined;
-      
-      const media = await loadWebMedia(mediaUrl, buildOutboundMediaLoadOptions({
-        mediaAccess: opts.mediaAccess,
-        mediaLocalRoots: opts.mediaLocalRoots,
-        mediaReadFile: opts.mediaReadFile,
-        maxBytes,
-      }));
-      const result = await uploadFile(client, {
-        roomId,
-        buffer: media.buffer,
-        fileName: media.fileName ?? "upload",
-        contentType: media.contentType ?? undefined,
-        description: message || undefined,
-        tmid: opts.replyToId,
-      });
+    const client = createRocketChatClient({ baseUrl, authToken, userId });
+    let message = text?.trim() ?? "";
+    let uploadError: Error | undefined;
+    const mediaUrl = opts.mediaUrl?.trim();
 
-      core.channel.activity.record({
+    if (mediaUrl) {
+      try {
+        const configuredMaxMb =
+          account.config.mediaMaxMb ??
+          cfg.channels?.rocketchat?.mediaMaxMb;
+        const maxBytes = configuredMaxMb && configuredMaxMb > 0
+          ? configuredMaxMb * 1024 * 1024
+          : undefined;
+
+        const media = await loadWebMedia(mediaUrl, buildOutboundMediaLoadOptions({
+          mediaAccess: opts.mediaAccess,
+          mediaLocalRoots: opts.mediaLocalRoots,
+          mediaReadFile: opts.mediaReadFile,
+          maxBytes,
+        }));
+        const result = await uploadFile(client, {
+          roomId,
+          buffer: media.buffer,
+          fileName: media.fileName ?? "upload",
+          contentType: media.contentType ?? undefined,
+          description: message || undefined,
+          tmid: opts.replyToId,
+        });
+
+        core.channel.activity.record({
+          channel: "rocketchat",
+          accountId: account.accountId,
+          direction: "outbound",
+        });
+
+        return {
+          messageId: result._id ?? "unknown",
+          roomId,
+        };
+      } catch (err) {
+        uploadError = err instanceof Error ? err : new Error(String(err));
+        if (core.logging.shouldLogVerbose()) {
+          logger.debug?.(
+            `rocketchat send: media upload failed, falling back to URL text: ${String(err)}`,
+          );
+        }
+        if (isHttpUrl(mediaUrl)) {
+          message = [message, mediaUrl].filter(Boolean).join("\n");
+        }
+      }
+    }
+
+    if (message) {
+      const tableMode = core.channel.text.resolveMarkdownTableMode({
+        cfg,
         channel: "rocketchat",
         accountId: account.accountId,
-        direction: "outbound",
       });
-
-      return {
-        messageId: result._id ?? "unknown",
-        roomId,
-      };
-    } catch (err) {
-      uploadError = err instanceof Error ? err : new Error(String(err));
-      if (core.logging.shouldLogVerbose()) {
-        logger.debug?.(
-          `rocketchat send: media upload failed, falling back to URL text: ${String(err)}`,
-        );
-      }
-      if (isHttpUrl(mediaUrl)) {
-        message = [message, mediaUrl].filter(Boolean).join("\n");
-      }
+      message = core.channel.text.convertMarkdownTables(message, tableMode);
     }
-  }
 
-  if (message) {
-    const tableMode = core.channel.text.resolveMarkdownTableMode({
-      cfg,
+    if (!message) {
+      if (uploadError) {
+        throw new Error(`Rocket.Chat media upload failed: ${uploadError.message}`);
+      }
+      throw new Error("Rocket.Chat message is empty");
+    }
+
+    const result = await sendMessage(client, {
+      roomId,
+      text: message,
+      tmid: opts.replyToId,
+    });
+
+    core.channel.activity.record({
       channel: "rocketchat",
       accountId: account.accountId,
+      direction: "outbound",
     });
-    message = core.channel.text.convertMarkdownTables(message, tableMode);
-  }
 
-  if (!message) {
-    if (uploadError) {
-      throw new Error(`Rocket.Chat media upload failed: ${uploadError.message}`);
-    }
-    throw new Error("Rocket.Chat message is empty");
-  }
-
-  const result = await sendMessage(client, {
-    roomId,
-    text: message,
-    tmid: opts.replyToId,
-  });
-
-  core.channel.activity.record({
-    channel: "rocketchat",
-    accountId: account.accountId,
-    direction: "outbound",
-  });
-
-  return {
-    messageId: result._id ?? "unknown",
-    roomId,
+    return {
+      messageId: result._id ?? "unknown",
+      roomId,
+    };
   };
+
+  try {
+    return await sendOnce();
+  } catch (error) {
+    if (!canRelogin || !isRocketChatAuthError(error)) {
+      throw error;
+    }
+    logger.info?.("rocketchat send: auth expired, refreshing login session and retrying once");
+    await ensureAuth(true);
+    return await sendOnce();
+  }
 }

--- a/test/channel-auth-config.test.ts
+++ b/test/channel-auth-config.test.ts
@@ -112,3 +112,97 @@ test("loginWithPassword and probeRocketChat support username/password auth flow"
     globalThis.fetch = originalFetch;
   }
 });
+
+test("loginWithPassword retries once when Rocket.Chat returns 429 with a wait window", async () => {
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+  globalThis.fetch = (async (input: URL | string) => {
+    const url = String(input);
+    if (url !== "https://chat-rate-limit.example.com/api/v1/login") {
+      throw new Error(`Unexpected fetch: ${url}`);
+    }
+    attempts += 1;
+    if (attempts === 1) {
+      return new Response(
+        JSON.stringify({
+          error:
+            "Error, too many requests. Please slow down. You must wait 0 seconds before trying this endpoint again. [error-too-many-requests]",
+        }),
+        {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    return new Response(
+      JSON.stringify({
+        status: "success",
+        data: { authToken: "token-429", userId: "user-429" },
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const login = await loginWithPassword({
+      baseUrl: "https://chat-rate-limit.example.com",
+      username: "bot-rate-limit",
+      password: "secret",
+    });
+    assert.deepEqual(login, { authToken: "token-429", userId: "user-429" });
+    assert.equal(attempts, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("loginWithPassword reuses cached sessions until forced refresh", async () => {
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+  globalThis.fetch = (async (input: URL | string) => {
+    const url = String(input);
+    if (url !== "https://chat-cache.example.com/api/v1/login") {
+      throw new Error(`Unexpected fetch: ${url}`);
+    }
+    attempts += 1;
+    return new Response(
+      JSON.stringify({
+        status: "success",
+        data: { authToken: `token-${attempts}`, userId: `user-${attempts}` },
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const first = await loginWithPassword({
+      baseUrl: "https://chat-cache.example.com",
+      username: "bot-cache",
+      password: "secret",
+    });
+    const second = await loginWithPassword({
+      baseUrl: "https://chat-cache.example.com",
+      username: "bot-cache",
+      password: "secret",
+    });
+    const refreshed = await loginWithPassword({
+      baseUrl: "https://chat-cache.example.com",
+      username: "bot-cache",
+      password: "secret",
+      forceRefresh: true,
+    });
+
+    assert.deepEqual(first, { authToken: "token-1", userId: "user-1" });
+    assert.deepEqual(second, first);
+    assert.deepEqual(refreshed, { authToken: "token-2", userId: "user-2" });
+    assert.equal(attempts, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- cache login-based Rocket.Chat sessions so reply sends stop re-authenticating on every send
- honor Rocket.Chat 429 wait windows during password login and retry gracefully
- refresh cached login sessions only when auth actually expires, and bump release metadata to v0.3.6

## Testing
- npm test
- npm run build

Closes #15