### PR TITLE
fix: compatibility with openclaw v2026.5.x

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,17 +1,11 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/core";
+import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
 import { rocketchatPlugin } from "./src/channel.js";
 import { setRocketChatRuntime } from "./src/runtime.js";
 
-const plugin = {
+export default defineChannelPluginEntry({
   id: "rocketchat",
   name: "Rocket.Chat",
   description: "Rocket.Chat channel plugin",
-  configSchema: emptyPluginConfigSchema(),
-  register(api: OpenClawPluginApi) {
-    setRocketChatRuntime(api.runtime);
-    api.registerChannel({ plugin: rocketchatPlugin });
-  },
-};
-
-export default plugin;
+  plugin: rocketchatPlugin,
+  setRuntime: setRocketChatRuntime,
+});

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "extensions": [
       "./dist/index.js"
     ],
+    "setupEntry": "./setup-entry.ts",
+    "runtimeSetupEntry": "./dist/setup-entry.js",
     "compat": {
       "pluginApi": "^2026.4.23"
     },

--- a/scripts/generate-manifest-schema.ts
+++ b/scripts/generate-manifest-schema.ts
@@ -18,6 +18,13 @@ const jsonSchema = z.toJSONSchema(RocketChatConfigSchema, { target: "draft-7" })
 
 manifest.version = packageJson.version;
 manifest.configSchema = jsonSchema;
+manifest.channelConfigs = {
+  rocketchat: {
+    label: "Rocket.Chat",
+    description: "Rocket.Chat channel plugin",
+    schema: jsonSchema,
+  },
+};
 
 fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n", "utf8");
 console.log(`[rocketchat] synced manifest version and configSchema to ${manifestPath}`);

--- a/setup-entry.ts
+++ b/setup-entry.ts
@@ -1,0 +1,3 @@
+import { defineSetupPluginEntry } from "openclaw/plugin-sdk/core";
+import { rocketchatPlugin } from "./src/channel.js";
+export default defineSetupPluginEntry(rocketchatPlugin);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -141,6 +141,14 @@ export const rocketchatPlugin: ChannelPlugin<ResolvedRocketChatAccount> = {
         clearBaseFields: ["authToken", "userId", "baseUrl", "name"],
       }),
     isConfigured: (account) => isRocketChatAccountConfigured(account),
+    hasConfiguredState: ({ cfg, env }) => {
+      const envToken = env?.ROCKETCHAT_AUTH_TOKEN?.trim();
+      const envUserId = env?.ROCKETCHAT_USER_ID?.trim();
+      const envUrl = env?.ROCKETCHAT_URL?.trim();
+      const account = resolveRocketChatAccount({ cfg });
+      return isRocketChatAccountConfigured(account) || 
+        Boolean(envUrl && envToken && envUserId);
+    },
     describeAccount: (account) => ({
       accountId: account.accountId,
       name: account.name,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,12 +1,13 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 
-let runtime: PluginRuntime | null = null;
+const RUNTIME_KEY = "__openclaw_rocketchat_runtime__";
 
 export function setRocketChatRuntime(next: PluginRuntime) {
-  runtime = next;
+  (globalThis as any)[RUNTIME_KEY] = next;
 }
 
 export function getRocketChatRuntime(): PluginRuntime {
+  const runtime = (globalThis as any)[RUNTIME_KEY];
   if (!runtime) {
     throw new Error("Rocket.Chat runtime not initialized");
   }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["index.ts"],
+  entry: ["index.ts", "setup-entry.ts"],
   format: ["esm"],
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
### Summary

Fixes compatibility with openclaw gateway v2026.5.x, which introduced breaking changes to how channel plugins are loaded and registered.

### Root causes

Three separate issues combined to break the plugin:

1. **Module loader isolation** — The gateway uses two independent module loader instances. The original `runtime.ts` stored the runtime as a module-level singleton, so `setRocketChatRuntime()` and `getRocketChatRuntime()` operated on different instances, meaning the runtime was always `null` when `startAccount` ran.

2. **Registration API change** — The gateway now expects plugins to use `defineChannelPluginEntry()` from the plugin SDK rather than a plain object with a `register()` method. The old pattern no longer correctly wires up `setChannelRuntime` in the loader.

3. **Missing `channelConfigs` manifest metadata** — The new gateway version requires `channelConfigs` in `openclaw.plugin.json` to surface config UI and determine registration mode before the plugin runtime loads. Without it, the gateway fell into `setup-runtime` mode even for configured channels, and the full plugin entry was never loaded.

### Changes

- `src/runtime.ts` — Store runtime on `globalThis` with a namespaced key so it's shared across all module loader instances
- `index.ts` — Switch to `defineChannelPluginEntry()` for correct SDK registration
- `src/channel.ts` — Add `hasConfiguredState()` so env-var-only credential setups (no credentials in `openclaw.json`) are correctly recognized as configured at load time
- `setup-entry.ts` + `package.json` — Add `setupEntry`/`runtimeSetupEntry` for correct first-time setup flow when the channel is unconfigured
- `scripts/generate-manifest-schema.ts` — Auto-generate `channelConfigs` from `configSchema` so it stays in sync without manual maintenance
- `tsup.config.ts` — Build both `index.ts` and `setup-entry.ts`

### Testing

Tested against openclaw v2026.5.6 with credentials supplied via env vars (`ROCKETCHAT_URL`, `ROCKETCHAT_AUTH_TOKEN`, `ROCKETCHAT_USER_ID`). Channel connects successfully on gateway startup and config UI renders correctly in the control panel.